### PR TITLE
Add support for "at least|most N entries" to functional tests

### DIFF
--- a/features/functional.feature
+++ b/features/functional.feature
@@ -7,7 +7,11 @@ Feature: Performing different rest methods
         When I request a list of posts with:
             | User Id | 8 |
         Then the request is successful
+        And the JSON response should have "$." of type array with at least 1 entry
+        And the JSON response should have "$." of type array with at least 10 entries
         And the JSON response should have "$." of type array with 10 entries
+        And the JSON response should have "$." of type array with at most 10 entries
+        And the JSON response should have "$." of type array with at most 11 entries
 
     Scenario: Check for null type
         When I request to create a post with:

--- a/lib/cucumber-rest-bdd/steps/functional.rb
+++ b/lib/cucumber-rest-bdd/steps/functional.rb
@@ -14,6 +14,12 @@ Then(/^the JSON response should have "([^"]*)" of type array with (\d+) entr(?:y
   raise %/Expected #{number} items in array for path '#{json_path}', found: #{list.count}\n#{@response.to_json_s}/ if list.count != number.to_i
 end
 
+Then(/^the JSON response should have "([^"]*)" of type array with at (least|most) (\d+) entr(?:y|ies)$/) do |json_path, comparator, number|
+  list = @response.get_as_type json_path, 'array'
+  raise %/Expected at #{comparator} #{number} items in array for path '#{json_path}', found: #{list.count}\n#{@response.to_json_s}/ \
+	if (comparator == "least" && list.count < number.to_i) || (comparator == "most" && list.count > number.to_i)
+end
+
 Then(/^the JSON response should have "([^"]*)" of type (.+) that matches "(.+)"$/) do |json_path, type, regex|
     value = @response.get_as_type json_path, type
     raise %/Expected #{json_path} value '#{value}' to match regex: #{regex}\n#{@response.to_json_s}/ if (Regexp.new(regex) =~ value).nil?

--- a/lib/cucumber-rest-bdd/steps/functional.rb
+++ b/lib/cucumber-rest-bdd/steps/functional.rb
@@ -1,5 +1,6 @@
 require 'cucumber-api/response'
 require 'cucumber-api/steps'
+require 'cucumber-rest-bdd/types'
 
 Then(/^the response (?:should have|has a|has the) header "([^"]*)" with (?:a |the )?value "([^"]*)"$/) do |header, value|
     p_value = resolve(value)
@@ -14,10 +15,10 @@ Then(/^the JSON response should have "([^"]*)" of type array with (\d+) entr(?:y
   raise %/Expected #{number} items in array for path '#{json_path}', found: #{list.count}\n#{@response.to_json_s}/ if list.count != number.to_i
 end
 
-Then(/^the JSON response should have "([^"]*)" of type array with at (least|most) (\d+) entr(?:y|ies)$/) do |json_path, comparator, number|
+Then(/^the JSON response should have "([^"]*)" of type array with (#{FEWER_MORE_THAN}) (\d+) entr(?:y|ies)$/) do |json_path, count_mod, number|
   list = @response.get_as_type json_path, 'array'
   raise %/Expected at #{comparator} #{number} items in array for path '#{json_path}', found: #{list.count}\n#{@response.to_json_s}/ \
-	if (comparator == "least" && list.count < number.to_i) || (comparator == "most" && list.count > number.to_i)
+	if !num_compare(count_mod, list.count, number.to_i)
 end
 
 Then(/^the JSON response should have "([^"]*)" of type (.+) that matches "(.+)"$/) do |json_path, type, regex|

--- a/lib/cucumber-rest-bdd/steps/functional.rb
+++ b/lib/cucumber-rest-bdd/steps/functional.rb
@@ -17,7 +17,7 @@ end
 
 Then(/^the JSON response should have "([^"]*)" of type array with (#{FEWER_MORE_THAN}) (\d+) entr(?:y|ies)$/) do |json_path, count_mod, number|
   list = @response.get_as_type json_path, 'array'
-  raise %/Expected at #{comparator} #{number} items in array for path '#{json_path}', found: #{list.count}\n#{@response.to_json_s}/ \
+  raise %/Expected #{count_mod} #{number} items in array for path '#{json_path}', found: #{list.count}\n#{@response.to_json_s}/ \
 	if !num_compare(count_mod, list.count, number.to_i)
 end
 


### PR DESCRIPTION
The Steps document says it supports this syntax for functional tests:

    Then the JSON response should have "$." of type array with at least 12 entries

But actually only checking for exact numbers is currently supported.

This PR adds support for least/most.